### PR TITLE
Fix Contributor Covenant Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,4 +235,4 @@ likelihood of causing circular dispatches.
 
 ## Contributing
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms. Multiple language translations are available at (contributor-covenant.org)[http://contributor-covenant.org/version/1/3/0/i18n/]
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms. Multiple language translations are available at [contributor-covenant.org](http://contributor-covenant.org/version/1/3/0/i18n/)


### PR DESCRIPTION
Fixes a typo in README to link correctly to the CoC page.