### PR TITLE
Use IE8-compatible ['catch'] syntax over .catch()

### DIFF
--- a/modules/install.js
+++ b/modules/install.js
@@ -52,7 +52,7 @@ export function install() {
           const materializedActions = [].concat(actions).filter(a => a);
           return Promise.all(materializedActions.map(dispatch));
         })
-        .catch((error) => {
+        ['catch']((error) => {
           console.error(
             `loop Promise caught when returned from action of type ${originalAction.type}.` +
             '\nloop Promises must not throw!'


### PR DESCRIPTION
Old versions of IE can't handle properties named catch that are accessed with dot syntax.