### PR TITLE
Pass the received enhancers to the next enhancer

### DIFF
--- a/modules/install.js
+++ b/modules/install.js
@@ -31,9 +31,9 @@ function liftReducer(reducer) {
  * attached to the current model as established by the original dispatch.
  */
 export function install() {
-  return (next) => (reducer, initialState) => {
+  return (next) => (reducer, initialState, enhancer) => {
     const liftedInitialState = liftState(initialState);
-    const store = next(liftReducer(reducer), liftedInitialState);
+    const store = next(liftReducer(reducer), liftedInitialState, enhancer);
 
     function dispatch(action) {
       const dispatchedAction = store.dispatch(action);


### PR DESCRIPTION
When not the outer enhancer, the next enhancer loses information about the previous ones. In order to fix this issue, we just need to pass the enhancer parameter if received.