### PR TITLE
Addresses #38, combineReducers can handle custom data structures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ properly identify effects from your nested reducers' results and execute them,
 and the `redux-loop` implementation is completely compatible with the behavior
 of the built-in version so there should be no problem with exchanging it.
 
-## Using redux-loop's `combineReducers` with Immutable.js (or any other data structure)
+#### Using redux-loop's `combineReducers` with Immutable.js (or any other data structure)
 
 ```javascript
 import { combineReducers } from 'redux-loop';

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ const reducer = combineReducers(
 ```
 
 Our `combineReducers` can also handle states made of data structures
-other than the default `{}`, you simple pass it in the root state,
+other than the default `{}`, you simply pass it in the root state,
 an accessor function (which returns a value for that key), and a mutator
 function (which returns a **new version** of the object with a value
 set at a given key). The example above demonstrates using Immutable.js'

--- a/README.md
+++ b/README.md
@@ -255,6 +255,37 @@ properly identify effects from your nested reducers' results and execute them,
 and the `redux-loop` implementation is completely compatible with the behavior
 of the built-in version so there should be no problem with exchanging it.
 
+## Using redux-loop's `combineReducers` with Immutable.js (or any other data structure)
+
+```javascript
+import { combineReducers } from 'redux-loop';
+import { Map } from 'immutable';
+
+import { firstReducer, secondReducer } from './reducers';
+
+const reducers = {
+  first: firstReducer,
+  second: secondReducer,
+}
+
+//Map() is now used as the new root state, and custom accessor and mutator properties are provided
+const reducer = combineReducers(
+    reducers,
+    Map(),
+    (child, key) => child.get(key),
+    (child, key, value) => child.set(key, value)
+);
+
+```
+
+Our `combineReducers` can also handle states made of data structures
+other than the default `{}`, you simple pass it in the root state,
+an accessor function (which returns a value for that key), and a mutator
+function (which returns a **new version** of the object with a value
+set at a given key). The example above demonstrates using Immutable.js'
+Map() data structure, but you can use any `key => value` data structure
+as long as you provide your own accessor and mutator functions.
+
 ### Avoid circular loops!
 
 ```javascript

--- a/modules/combineReducers.js
+++ b/modules/combineReducers.js
@@ -36,8 +36,6 @@ export function combineReducers(
             return mutator(model, key, nextStateForKey);
         }, rootState);
 
-        console.log(model);
-
         return loop(
             hasChanged ? model : state,
             optimizeBatch(effects)

--- a/modules/combineReducers.js
+++ b/modules/combineReducers.js
@@ -13,7 +13,8 @@ function optimizeBatch(effects) {
 }
 
 export function combineReducers(
-    reducerMap, rootState = {}, 
+    reducerMap,
+    rootState = {}, 
     accessor = (child, key) => child[key],
     mutator = (child, key, value) => { child[key] = value; return child; }
 ) {

--- a/modules/combineReducers.js
+++ b/modules/combineReducers.js
@@ -12,7 +12,7 @@ function optimizeBatch(effects) {
   }
 }
 
-function combineReducers(reducerMap, rootState = {}, accessor, mutator) {
+export function combineReducers(reducerMap, rootState = {}, accessor, mutator) {
     if (typeof accessor !== 'function') {
         accessor = (child, key) => child[key];
     }

--- a/modules/combineReducers.js
+++ b/modules/combineReducers.js
@@ -12,13 +12,11 @@ function optimizeBatch(effects) {
   }
 }
 
-export function combineReducers(reducerMap, rootState = {}, accessor, mutator) {
-    if (typeof accessor !== 'function') {
-        accessor = (child, key) => child[key];
-    }
-    if (typeof mutator !== 'function') {
-        mutator = (child, key, value) => { child[key] = value; return child; };
-    }
+export function combineReducers(
+    reducerMap, rootState = {}, 
+    accessor = (child, key) => child[key],
+    mutator = (child, key, value) => { child[key] = value; return child; }
+) {
     return function finalReducer(state = {}, action) {
         let hasChanged = false;
         let effects = [];

--- a/modules/combineReducers.js
+++ b/modules/combineReducers.js
@@ -18,7 +18,7 @@ export function combineReducers(
     accessor = (child, key) => child[key],
     mutator = (child, key, value) => { child[key] = value; return child; }
 ) {
-    return function finalReducer(state = {}, action) {
+    return function finalReducer(state = rootState, action) {
         let hasChanged = false;
         let effects = [];
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-polyfill": "6.7.2",
     "babel-preset-es2015": "6.3.13",
     "babel-register": "6.7.2",
+    "immutable": "^3.7.6",
     "redux": "3.0.5",
     "rimraf": "2.4.4",
     "tape": "4.5.1"

--- a/test/combineReducers.test.js
+++ b/test/combineReducers.test.js
@@ -1,0 +1,81 @@
+import test from 'tape';
+import { combineReducers } from '../modules';
+import { getModel } from '../modules/loop';
+import { Map } from 'immutable';
+
+const reducers = {
+    counter: (state = 0, action = {}) => state + 1,
+    doubler: (state, action = {}) => state ? state + state : 1,
+    fibonacci: (state = 1, action = {}) => action.previous ? action.previous + state : state
+};
+
+test('combineReducers works with one argument and returns correctly working reducer', (t) => {
+    const appReducer = combineReducers(reducers);
+
+    t.equals(typeof appReducer, 'function');
+
+    let state = getModel(appReducer());
+    t.deepEqual(state, { counter: 1, doubler: 1, fibonacci: 1 });
+
+    let action = {
+        type: 'NEXT FIBONACCI NUMBER',
+        previous: 0
+    };
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state, { counter: 2, doubler: 2, fibonacci: 1 });
+
+    action.previous = 1;
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state, { counter: 3, doubler: 4, fibonacci: 2 });
+
+    state = getModel(appReducer(state));
+    t.deepEqual(state, { counter: 4,  doubler: 8, fibonacci: 2 });
+
+    action.previous = 1;
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state, { counter: 5, doubler: 16, fibonacci: 3 });
+
+    action.previous = 2;
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state, { counter: 6, doubler: 32, fibonacci: 5 });
+
+    t.end();
+});
+
+test('combineReducers works with custom data structure and returns correctly working reducer', (t) => {
+    const appReducer = combineReducers(
+        reducers,
+        Map(),
+        (child, key) => child.get(key),
+        (child, key, value) => child.set(key, value)
+    );
+
+    t.equals(typeof appReducer, 'function');
+
+    let state = getModel(appReducer());
+    t.deepEqual(state.toJS(), { counter: 1, doubler: 1, fibonacci: 1 });
+
+    let action = {
+        type: 'NEXT FIBONACCI NUMBER',
+        previous: 0
+    };
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state.toJS(), { counter: 2, doubler: 2, fibonacci: 1 });
+
+    action.previous = 1;
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state.toJS(), { counter: 3, doubler: 4, fibonacci: 2 });
+
+    state = getModel(appReducer(state));
+    t.deepEqual(state.toJS(), { counter: 4,  doubler: 8, fibonacci: 2 });
+
+    action.previous = 1;
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state.toJS(), { counter: 5, doubler: 16, fibonacci: 3 });
+
+    action.previous = 2;
+    state = getModel(appReducer(state, action));
+    t.deepEqual(state.toJS(), { counter: 6, doubler: 32, fibonacci: 5 });
+
+    t.end();
+});


### PR DESCRIPTION
I returned to a reduce function on the object.keys, as I don't see it being any less efficient, and personally I much prefer it to a for loop, but I kept some of the changes from #36 which did increase efficiency. Let me know what you think.