### PR TITLE
Return dispatch result if effect is none

### DIFF
--- a/modules/effects.js
+++ b/modules/effects.js
@@ -2,7 +2,7 @@ import { throwInvariant, flatten } from './utils';
 
 const isEffectSymbol = Symbol('isEffect');
 
-const effectTypes = {
+export const effectTypes = {
   PROMISE: 'PROMISE',
   CALL: 'CALL',
   BATCH: 'BATCH',

--- a/modules/install.js
+++ b/modules/install.js
@@ -14,6 +14,7 @@ import {
   none,
   isEffect,
   effectToPromise,
+  effectTypes
 } from './effects';
 
 /**
@@ -46,10 +47,16 @@ export function install() {
     };
 
     const dispatch = (action) => {
-      store.dispatch(action);
-      const effectToRun = currentEffect;
-      currentEffect = none();
-      return runEffect(action, effectToRun);
+      const result = store.dispatch(action);
+
+      if (currentEffect.type !== effectTypes.NONE) {
+        const effectToRun = currentEffect
+        currentEffect = none();
+
+        return runEffect(action, effectToRun)
+      }
+
+      return result;
     };
 
     const replaceReducer = (reducer) => {


### PR DESCRIPTION
Dispatch returns actions as effect promises. But not all actions have an effect, so not all actions should return an effect promise. To fix this we return the result of `store.dispatch` whenever the effect type is `NONE`.
 
This change would avoid breaking a store with middleware that intercepts actions—here are some examples:
```es6
// intercepts a fetch action and returns a promise
const APIMiddleware = (store) => (next) => (action) =>
  action.type === 'FETCH' ?
    fetch(action.url, action.options) : next(action)

// intercepts an interval action and returns a new action to unset the interval
const TimingMiddleware = (store) => (next) => (action) => {
  switch (action.type) {
    case 'SET_INTERVAL':
      return {
        type: 'UNSET_INTERVAL',
        id: setInterval(() => 
          store.dispatch(action.action), action.duration)
      }
    case 'UNSET_INTERVAL':
      clearInterval(action.id)
  }
  
  return next(action)
}

const enhancer = compose(
  install(),
  applyMiddleware(
    APIMiddleware,
    TimingMiddleware
  )
)
const store = createStore(reducer, enhancer);

class App extends Component {
  componentDidMount() {
    // returns a promise from the APIMiddleware
    this.props.dispatch({ type: 'FETCH', url }).
    then((result) =>
      // returns an action from the TimingMiddleware
      this.unsetInterval = this.props.dispatch({
        type: 'SET_INTERVAL'
        action: { type: 'FETCH', url }
      })
    )
  }

  componentWillUnmount() {
    this.unsetInterval &&
      this.props.dispatch(unsetInterval);
  }

  render() {
    return <div/>
  }
}

const Root = connector(App);
```